### PR TITLE
fix: i18n: en-US name duplication

### DIFF
--- a/i18n.ts
+++ b/i18n.ts
@@ -5,11 +5,13 @@ import { initReactI18next } from "react-i18next";
 import enUS from "src/i18n/en-US.json";
 import frFR from "src/i18n/fr-FR.json";
 
+export const supportedLanguages = ["en-US", "fr-FR"];
+
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    fallbackLng: ["en-US", "fr-FR"],
+    fallbackLng: supportedLanguages,
     debug: false,
     interpolation: {
       escapeValue: false,

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -15,7 +15,7 @@ import NavDropDown from "@/components/layout/NavDropDown";
 import NavDropDownLink from "@/components/layout/NavDropDownLink";
 import NavLink from "@/components/layout/NavLink";
 import type { PageSoftwareProps } from "@/lib/util/types";
-import i18n from "i18n";
+import i18n, { supportedLanguages } from "i18n";
 
 export interface NavBarProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -90,31 +90,7 @@ const NavBar = ({ component }: NavBarProps) => {
           </NavLink>
           <div className="md:hidden" />
           <NavDropDown label={t("Language")} className="md:hidden">
-            {Array.from(i18n.languages)
-              .filter((language) => language !== "en")
-              .filter((language) => language !== "fr")
-              .filter((language) => language !== "zh")
-              .map((language) => (
-                <NavDropDownLink
-                  href=""
-                  key={language}
-                  onClick={() => {
-                    i18n.changeLanguage(language);
-                  }}
-                >
-                  {i18n.getFixedT(language)("name")}
-                </NavDropDownLink>
-              ))}
-          </NavDropDown>
-        </div>
-
-        <div className="flex-grow" />
-        <NavDropDown label={t("Language")} className="invisible md:visible">
-          {Array.from(i18n.languages)
-            .filter((language) => language !== "en")
-            .filter((language) => language !== "fr")
-            .filter((language) => language !== "zh")
-            .map((language) => (
+            {supportedLanguages.map((language) => (
               <NavDropDownLink
                 href=""
                 key={language}
@@ -125,6 +101,22 @@ const NavBar = ({ component }: NavBarProps) => {
                 {i18n.getFixedT(language)("name")}
               </NavDropDownLink>
             ))}
+          </NavDropDown>
+        </div>
+
+        <div className="flex-grow" />
+        <NavDropDown label={t("Language")} className="invisible md:visible">
+          {supportedLanguages.map((language) => (
+            <NavDropDownLink
+              href=""
+              key={language}
+              onClick={() => {
+                i18n.changeLanguage(language);
+              }}
+            >
+              {i18n.getFixedT(language)("name")}
+            </NavDropDownLink>
+          ))}
         </NavDropDown>
         <IconButton
           icon={DiscordIcon}


### PR DESCRIPTION
Fixed a problem concerning language drop-down, where `en-US` would be rendered wrongly (duplication) when no valid locale data is set in storage.